### PR TITLE
Surge v2ray native support

### DIFF
--- a/docs/guide/custom-config.md
+++ b/docs/guide/custom-config.md
@@ -69,7 +69,7 @@ module.exports = {
 
 ### upload
 
-- 类型: ` UploadConfig`
+- 类型: `Object`
 - 默认值: `undefined`
 
 上传阿里云 OSS 的配置。
@@ -135,3 +135,20 @@ V2Ray 的可执行文件地址，通常是 `/usr/local/bin/v2ray`。
 - 默认值: `undefined`
 
 SSR 的可执行文件地址。请使用 libev 版本的二进制文件，可以在 [这篇文章](/guide/surge-advance.md) 找到下载地址和使用方法。
+
+### surgeConfig
+
+- 类型: `Object`
+- 默认值: `undefined`
+
+#### surgeConfig.v2ray
+
+- 类型: `string`
+- 默认值: `external`
+- 可选值: `external|native`
+
+:::warning 注意
+仅 Surge 4 for iOS 和 Surge 3.3.1 (894) for macOS 之后的版本支持 `native` 方式。
+:::
+
+定义生成 Vmess 节点配置的类型，默认使用 External Provider 的形式，兼容性更好。也可以选择使用 `native` 的方式。

--- a/lib/generate.ts
+++ b/lib/generate.ts
@@ -119,6 +119,8 @@ export async function generate(
         nodeConfig.localPort = provider.nextPort;
       }
 
+      nodeConfig.surgeConfig = config.surgeConfig;
+
       if (isValid) {
         nodeNameList.push({
           type: nodeConfig.type,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -37,6 +37,9 @@ export interface CommandConfig {
     readonly v2ray?: string;
     vmess?: string; // tslint:disable-line
   };
+  readonly surgeConfig: {
+    readonly v2ray: 'native'|'external';
+  };
 }
 
 export interface RemoteSnippetConfig {
@@ -150,6 +153,7 @@ export interface SimpleNodeConfig {
   readonly nodeName: string;
   binPath?: string; // tslint:disable-line
   localPort?: number; // tslint:disable-line
+  surgeConfig?: CommandConfig['surgeConfig']; // tslint:disable-line
 }
 
 export interface PlainObject { readonly [name: string]: any }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -141,7 +141,7 @@ export interface VmessNodeConfig extends SimpleNodeConfig {
   readonly method: string;
   readonly uuid: string;
   readonly alterId: string;
-  readonly network: string;
+  readonly network: 'tcp' | 'kcp' | 'ws' | 'http' ;
   readonly tls: boolean;
   readonly host: string;
   readonly path: string;

--- a/lib/utils/config.ts
+++ b/lib/utils/config.ts
@@ -1,0 +1,36 @@
+import fs from 'fs-extra';
+import _ from 'lodash';
+import path from 'path';
+
+import { CommandConfig } from '../types';
+import { ensureConfigFolder } from './index';
+
+export const normalizeConfig = (cwd: string, obj: Partial<CommandConfig>): CommandConfig => {
+  const defaultConfig: Partial<CommandConfig> = {
+    artifacts: [],
+    urlBase: '/',
+    output: path.join(cwd, './dist'),
+    templateDir: path.join(cwd, './template'),
+    providerDir: path.join(cwd, './provider'),
+    configDir: ensureConfigFolder(),
+    upload: {
+      region: 'oss-cn-hangzhou',
+      prefix: '/',
+    },
+    surgeConfig: {
+      v2ray: 'external',
+    },
+  };
+  const config: CommandConfig = _.defaultsDeep(obj, defaultConfig);
+
+  // istanbul ignore next
+  if (!fs.existsSync(config.templateDir)) {
+    throw new Error(`You must create ${config.templateDir} first.`);
+  }
+  // istanbul ignore next
+  if (!fs.existsSync(config.providerDir)) {
+    throw new Error(`You must create ${config.providerDir} first.`);
+  }
+
+  return config;
+};

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -74,7 +74,41 @@ test('getSurgeNodes', async t => {
     uuid: '1386f85e-657b-4d6e-9d56-78badb75e1fd',
     binPath: '/usr/local/bin/v2ray',
     localPort: 61101,
-  },];
+  }, {
+    type: NodeTypeEnum.Vmess,
+    alterId: '64',
+    hostname: '1.1.1.1',
+    method: 'auto',
+    network: 'ws',
+    nodeName: '测试 4',
+    path: '/',
+    port: 8080,
+    tls: true,
+    host: '',
+    uuid: '1386f85e-657b-4d6e-9d56-78badb75e1fd',
+    binPath: '/usr/local/bin/v2ray',
+    localPort: 61101,
+    surgeConfig: {
+      v2ray: 'native',
+    }
+  }, {
+    type: NodeTypeEnum.Vmess,
+    alterId: '64',
+    hostname: '1.1.1.1',
+    method: 'auto',
+    network: 'tcp',
+    nodeName: '测试 5',
+    path: '/',
+    port: 8080,
+    tls: false,
+    host: '',
+    uuid: '1386f85e-657b-4d6e-9d56-78badb75e1fd',
+    binPath: '/usr/local/bin/v2ray',
+    localPort: 61101,
+    surgeConfig: {
+      v2ray: 'native',
+    }
+  }];
   const txt1 = utils.getSurgeNodes(nodeList).split('\n');
   const txt2 = utils.getSurgeNodes(nodeList, nodeConfig => nodeConfig.nodeName === 'Test Node 1');
 
@@ -82,6 +116,8 @@ test('getSurgeNodes', async t => {
   t.is(txt1[1], 'Test Node 2 = custom, example2.com, 443, chacha20-ietf-poly1305, password, https://raw.githubusercontent.com/ConnersHua/SSEncrypt/master/SSEncrypt.module');
   t.is(txt1[2], '测试中文 = external, exec = "/usr/local/bin/ssr-local", args = "-s", args = "127.0.0.1", args = "-p", args = "1234", args = "-m", args = "aes-128-cfb", args = "-o", args = "tls1.2_ticket_auth", args = "-O", args = "auth_aes128_md5", args = "-k", args = "aaabbb", args = "-l", args = "61100", args = "-b", args = "127.0.0.1", args = "-g", args = "breakwa11.moe", local-port = 61100, addresses = 127.0.0.1');
   t.is(txt1[3], '测试 3 = external, exec = "/usr/local/bin/v2ray", args = "--config", args = "$HOME/.config/surgio/v2ray_61101_1.1.1.1_8080.json", local-port = 61101, addresses = 1.1.1.1');
+  t.is(txt1[4], '测试 4 = vmess, 1.1.1.1, 8080, username=1386f85e-657b-4d6e-9d56-78badb75e1fd, ws=true, ws-path=/, ws-headers=Host:1.1.1.1|User-Agent:Mozilla/5.0 (iPhone; CPU iPhone OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148, tls=true');
+  t.is(txt1[5], '测试 5 = vmess, 1.1.1.1, 8080, username=1386f85e-657b-4d6e-9d56-78badb75e1fd');
   t.is(txt2, 'Test Node 1 = custom, example.com, 443, chacha20-ietf-poly1305, password, https://raw.githubusercontent.com/ConnersHua/SSEncrypt/master/SSEncrypt.module, udp-relay=true, obfs=tls, obfs-host=example.com');
 });
 


### PR DESCRIPTION
以下为 Surge 对 Vmess 原生支持的描述：

> All proxy options for TLS proxy are available. Please note that if you use the 'Host' header to override the default header, you may need to override the 'Origin' header to get rid of the 403 error.
>
> Web-socket and TLS options would degrade performance. Only enable when necessary.
>
> Surge only supports chacha20-poly1305 encryption algorithm. Please make sure the server supports it. We have no plan to implement other ciphers.
>
> Snell and shadowsocks are still the most recommended protocols. 
