### PR TITLE
Change proxy test URL to oversea servers

### DIFF
--- a/docs/guide/custom-config.md
+++ b/docs/guide/custom-config.md
@@ -242,7 +242,7 @@ module.exports = {
 ### proxyTestUrl <Badge text="v1.4.0" vertical="middle" />
 
 - 类型: `string`
-- 默认值: `http://www.qualcomm.cn/generate_204`
+- 默认值: `http://cp.cloudflare.com/generate_204`
 
 Clash 规则中的 `url`。
 

--- a/docs/guide/custom-template.md
+++ b/docs/guide/custom-template.md
@@ -52,7 +52,7 @@ Surgio 为了能够灵活地定义模板而引入了 [Nunjucks](https://nunjucks
 ### proxyTestUrl <Badge text="v1.6.0" vertical="middle" />
 
 - 类型: `string`
-- 默认值: `http://www.qualcomm.cn/generate_204`
+- 默认值: `http://cp.cloudflare.com/generate_204`
 
 节点测试地址。Surgio 会内置一个推荐的测试地址，你可以直接在模板文件中使用。如果在设置中使用了新的地址，这里也会变成所设的值。
 

--- a/examples/quantumultx/template/quantumultx.tpl
+++ b/examples/quantumultx/template/quantumultx.tpl
@@ -1,7 +1,7 @@
 # https://github.com/crossutility/Quantumult-X/blob/master/sample.conf
 
 [general]
-server_check_url=http://www.qualcomm.cn/generate_204
+server_check_url=http://cp.cloudflare.com/generate_204
 
 [dns]
 server=223.5.5.5

--- a/lib/utils/constant.ts
+++ b/lib/utils/constant.ts
@@ -6,7 +6,7 @@ export const NETWORK_CONCURRENCY = process.env.SURGIO_NETWORK_CONCURRENCY ? Numb
 
 export const OBFS_UA = 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148';
 
-export const PROXY_TEST_URL = 'http://www.qualcomm.cn/generate_204';
+export const PROXY_TEST_URL = 'http://cp.cloudflare.com/generate_204';
 
 export const PROXY_TEST_INTERVAL = 1200;
 


### PR DESCRIPTION
It doesn't quite make sense to have a domestic proxy test URL which will be used to test latency of oversea proxy endpoints. Ideally, the test servers should be distributed worldwide. So I chose Cloudflare's server (Google is good but may lead to human machine test when users attempt to access Google).