### PR TITLE
feat: discard domains not resolvable

### DIFF
--- a/docs/guide/custom-config.md
+++ b/docs/guide/custom-config.md
@@ -271,3 +271,10 @@ Clash 规则中的 `interval`。
 1. 全局模板变量的用法和 Artifact 中定义的模板变量相同，相关文档请查阅 [这里](/guide/custom-artifact.md#customparams)；
 2. 在合并全局、局部模板变量和面板 URL 参数时的优先级为：URL 参数 > 局部 > 全局；
 :::
+
+### checkHostname
+
+- 类型: `boolean`
+- 默认值: `false`
+
+是否丢弃无法解析出域名 IP 地址的节点。无法解析出域名的节点有可能会导致 Clash 的 `url-test` 模式抛出异常而中止，丢弃这些节点可以避免这个问题。如果不是用公共 DNS 解析节点域名，或者有其它机制，可以关闭此项检测。

--- a/lib/generator/artifact.ts
+++ b/lib/generator/artifact.ts
@@ -374,6 +374,19 @@ export class Artifact extends EventEmitter {
           nodeConfig.mptcp = provider.mptcp;
         }
 
+        // check whether the hostname resolves in case of blocking clash's node heurestic
+        if (
+          config?.checkHostname &&
+          !isIp(nodeConfig.hostname)
+        ) {
+          try {
+            await resolveDomain(nodeConfig.hostname);
+          } catch (err) /* istanbul ignore next */ {
+            logger.warn(`${nodeConfig.hostname} 无法解析，将忽略该节点`);
+            return undefined;
+          }
+        }
+
         if (
           config?.surgeConfig?.resolveHostname &&
           !isIp(nodeConfig.hostname) &&

--- a/lib/generator/artifact.ts
+++ b/lib/generator/artifact.ts
@@ -380,7 +380,11 @@ export class Artifact extends EventEmitter {
           !isIp(nodeConfig.hostname)
         ) {
           try {
-            await resolveDomain(nodeConfig.hostname);
+            const domains = await resolveDomain(nodeConfig.hostname);
+            if (domains.length < 1) {
+              logger.warn(`DNS 解析结果中 ${nodeConfig.hostname} 未有对应 IP 地址，将忽略该节点`);
+              return undefined;
+            }
           } catch (err) /* istanbul ignore next */ {
             logger.warn(`${nodeConfig.hostname} 无法解析，将忽略该节点`);
             return undefined;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -32,6 +32,7 @@ export interface CommandConfig {
   readonly templateDir: string;
   readonly configDir: string;
   readonly analytics?: boolean;
+  readonly checkHostname?: boolean;
   readonly upload?: {
     readonly prefix: string;
     readonly region: string;

--- a/lib/utils/config.ts
+++ b/lib/utils/config.ts
@@ -52,6 +52,7 @@ export const normalizeConfig = (cwd: string, userConfig: Partial<CommandConfig>)
     },
     proxyTestUrl: PROXY_TEST_URL,
     proxyTestInterval: PROXY_TEST_INTERVAL,
+    checkHostname: false,
   };
   const config: CommandConfig = _.defaultsDeep(userConfig, defaultConfig);
 


### PR DESCRIPTION
Add an option to drop nodes without a resolvable domain, since non-resolvable domain may cause problem for clash's `url-test` mode. It should be addressed by clash as well. But introducing such an option may also gain some performance.